### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: true
 
     - name: Build image
-      uses: elgohr/Publish-Docker-Github-Action@2.8
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         dockerfile: Dockerfile
         name: abogatikov/docker-helm/docker-helm


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore